### PR TITLE
Добавлена возможность обновления и удаления профиля пользователя

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -4,11 +4,13 @@
         "-//Puppy Crawl//DTD Suppressions 1.0//EN"
         "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
 
+<!--Подавляет испекции для контейнеров запроса и ответа, т.к. использование  открытых полей в них оправданно-->
 <suppressions>
     <suppress checks="VisibilityModifier" files="ApiErrorResponseEntiry.java"/>
     <suppress checks="VisibilityModifier" files="ApiMessageResponseEntity.java"/>
     <suppress checks="VisibilityModifier" files="ScoreboardResponseEntity.java"/>
     <suppress checks="VisibilityModifier" files="SigninRequestEntity.java"/>
+    <suppress checks="VisibilityModifier" files="UserPartialRequestEntity.java"/>
     <suppress checks="VisibilityModifier" files="UserRequestEntity.java"/>
     <suppress checks="VisibilityModifier" files="AbstractModel.java"/>
     <suppress checks="VisibilityModifier" files="User.java"/>

--- a/src/main/java/ru/shipcollision/api/controllers/MeController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/MeController.java
@@ -1,14 +1,21 @@
 package ru.shipcollision.api.controllers;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import ru.shipcollision.api.entities.ApiMessageResponseEntity;
+import ru.shipcollision.api.entities.UserPartialRequestEntity;
+import ru.shipcollision.api.entities.UserRequestEntity;
 import ru.shipcollision.api.exceptions.ForbiddenException;
 import ru.shipcollision.api.exceptions.NotFoundException;
+import ru.shipcollision.api.exceptions.PasswordConfirmationException;
 import ru.shipcollision.api.helpers.SessionHelper;
+import ru.shipcollision.api.models.User;
 
 import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
 
 /**
  * Контроллер для доступа к методам текущего пользователя.
@@ -20,5 +27,38 @@ public class MeController {
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity doGetMe(HttpSession session) throws ForbiddenException, NotFoundException {
         return ResponseEntity.ok().body(new SessionHelper(session).getCurrentUser());
+    }
+
+    @RequestMapping(method = RequestMethod.PUT)
+    public ResponseEntity doPutMe(@RequestBody @Valid UserRequestEntity updateUserRequest,
+                                  HttpSession session) throws ForbiddenException,
+            NotFoundException,
+            PasswordConfirmationException {
+        final User currentUser = new SessionHelper(session).getCurrentUser();
+        currentUser.update(updateUserRequest);
+        currentUser.save();
+        return ResponseEntity.ok().body(currentUser);
+    }
+
+    @RequestMapping(method = RequestMethod.PATCH)
+    public ResponseEntity doPathMe(@RequestBody @Valid UserPartialRequestEntity updateUserRequest,
+                                   HttpSession session) throws ForbiddenException,
+            NotFoundException,
+            PasswordConfirmationException {
+        final User currentUser = new SessionHelper(session).getCurrentUser();
+        currentUser.partialUpdate(updateUserRequest);
+        currentUser.save();
+        return ResponseEntity.ok().body(currentUser);
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE)
+    public ResponseEntity doDeleteMe(HttpSession session) throws ForbiddenException, NotFoundException {
+        final SessionHelper sessionHelper = new SessionHelper(session);
+        final User currentUser = sessionHelper.getCurrentUser();
+        sessionHelper.closeSession();
+        currentUser.delete();
+        return ResponseEntity.ok().body(new ApiMessageResponseEntity(
+                "Your profile has been delete successfully. You are signed out"
+        ));
     }
 }

--- a/src/main/java/ru/shipcollision/api/controllers/UsersController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/UsersController.java
@@ -6,9 +6,9 @@ import org.springframework.web.bind.annotation.*;
 import ru.shipcollision.api.entities.ApiMessageResponseEntity;
 import ru.shipcollision.api.entities.ScoreboardResponseEntity;
 import ru.shipcollision.api.entities.UserRequestEntity;
-import ru.shipcollision.api.exceptions.ApiException;
 import ru.shipcollision.api.exceptions.NotFoundException;
 import ru.shipcollision.api.exceptions.PaginationException;
+import ru.shipcollision.api.exceptions.PasswordConfirmationException;
 import ru.shipcollision.api.helpers.Paginator;
 import ru.shipcollision.api.helpers.SessionHelper;
 import ru.shipcollision.api.models.AbstractModel;
@@ -16,7 +16,6 @@ import ru.shipcollision.api.models.User;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
-import javax.validation.ValidationException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -51,7 +50,7 @@ public class UsersController {
     @RequestMapping(method = RequestMethod.POST, consumes = "application/json")
     public ResponseEntity doPostUser(HttpServletRequest request,
                                      @Valid @RequestBody UserRequestEntity requestBody,
-                                     HttpSession session) throws ApiException {
+                                     HttpSession session) throws PasswordConfirmationException {
         try {
             final User user = User.fromUserRequestEntity(requestBody);
             user.save();
@@ -64,8 +63,6 @@ public class UsersController {
             return ResponseEntity.ok().body(new ApiMessageResponseEntity(
                     "User has been created successfully, no resource URI available"
             ));
-        } catch (ValidationException error) {
-            throw new ApiException(error);
         }
     }
 

--- a/src/main/java/ru/shipcollision/api/entities/UserPartialRequestEntity.java
+++ b/src/main/java/ru/shipcollision/api/entities/UserPartialRequestEntity.java
@@ -1,0 +1,38 @@
+package ru.shipcollision.api.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.Email;
+
+/**
+ * Запрос на частичное обновление пользователя.
+ */
+@SuppressWarnings("PublicField")
+public class UserPartialRequestEntity {
+
+    @Nullable
+    @JsonProperty("nickname")
+    public String nickName;
+
+    @Nullable
+    @JsonProperty("email")
+    public @Email String email;
+
+    @Nullable
+    @JsonProperty("password")
+    public @Length(min = 6, message = "Password must be at least 6 characters") String password;
+
+    @Nullable
+    @JsonProperty("passwordConfirmation")
+    public String confirmation;
+
+    public boolean hasPassword() {
+        return password != null;
+    }
+
+    public boolean passwordConfirmed() {
+        return password != null && confirmation != null && password.equals(confirmation);
+    }
+}

--- a/src/main/java/ru/shipcollision/api/entities/UserRequestEntity.java
+++ b/src/main/java/ru/shipcollision/api/entities/UserRequestEntity.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 /**
- * Запрос на создание пользователя.
+ * Запрос на создание и полное обновление пользователя.
  */
 @SuppressWarnings("PublicField")
 public class UserRequestEntity {

--- a/src/main/java/ru/shipcollision/api/exceptions/ApiException.java
+++ b/src/main/java/ru/shipcollision/api/exceptions/ApiException.java
@@ -32,12 +32,6 @@ public class ApiException extends Exception {
         this.httpStatus = getDefaultHttpStatus();
     }
 
-    public ApiException(Exception exception) {
-        super(exception);
-        this.errorResponse = new ApiErrorResponseEntiry(exception.getMessage(), getDefaultErrorCode());
-        this.httpStatus = getDefaultHttpStatus();
-    }
-
     protected String getDefaultErrorMessage() {
         return "Error occured";
     }

--- a/src/main/java/ru/shipcollision/api/exceptions/PasswordConfirmationException.java
+++ b/src/main/java/ru/shipcollision/api/exceptions/PasswordConfirmationException.java
@@ -1,0 +1,17 @@
+package ru.shipcollision.api.exceptions;
+
+/**
+ * Ошибка подтверждения пароля.
+ */
+public class PasswordConfirmationException extends ApiException {
+
+    @Override
+    protected String getDefaultErrorMessage() {
+        return "Password confirmation failed";
+    }
+
+    @Override
+    protected String getDefaultErrorCode() {
+        return "password_confirmation";
+    }
+}


### PR DESCRIPTION
Реализовано:

* [x] возможность полного обновления профиля пользователя методом `PUT` - можно указать только все поля, присвоение также произойдет во все поля, если есть необязательные поля (которые можно устанавливать через запрос), они будут занулены (спойлер - таких полей у нас пока что нет);
* [x] возможность частичного обновления профиля пользователя методом `PATCH` - указываем только те поля, которые хотим обновить, и обновляем только их, остальные не трогаем.
* [x] возможность удаления профиля текущего пользователя.

Все это входит в MeAPI, так как по идее менять что-то должен только залогиненный пользователь и только у себя.