### PR TITLE
Загрузка аватарок

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fabric.properties
 #Gedit
 *~
 bin/*
+
+# Custom file uploads
+uploads/

--- a/src/main/java/ru/shipcollision/api/StaticResourcesConfiguration.java
+++ b/src/main/java/ru/shipcollision/api/StaticResourcesConfiguration.java
@@ -19,7 +19,7 @@ public class StaticResourcesConfiguration implements WebMvcConfigurer {
         /*
          * Если убрать / в конце, то все поломается. При этом toAbsolutePath по умолчанию убирает слеш!
          * Вы будете писать GET http://localhost:8080/uploads/2018/3/8/file.png,
-         * а он будет маппить в uploads(нет слеша)2018/3/8/file.png
+         * а он будет маппить в uploads(нет слеша)2018/3/8/file.png и естественно ничего не найдет!
          */
         final String resourseLocation = "file://" + Paths.get("uploads").toAbsolutePath().toString() + '/';
         registry.addResourceHandler("/uploads/**")

--- a/src/main/java/ru/shipcollision/api/StaticResourcesConfiguration.java
+++ b/src/main/java/ru/shipcollision/api/StaticResourcesConfiguration.java
@@ -1,0 +1,28 @@
+package ru.shipcollision.api;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
+
+/**
+ * Отдает аватарки как статику.
+ */
+@Configuration
+@EnableWebMvc
+public class StaticResourcesConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        /*
+         * Если убрать / в конце, то все поломается. При этом toAbsolutePath по умолчанию убирает слеш!
+         * Вы будете писать GET http://localhost:8080/uploads/2018/3/8/file.png,
+         * а он будет маппить в uploads(нет слеша)2018/3/8/file.png
+         */
+        final String resourseLocation = "file://" + Paths.get("uploads").toAbsolutePath().toString() + '/';
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(resourseLocation);
+    }
+}

--- a/src/main/java/ru/shipcollision/api/StaticResourcesConfiguration.java
+++ b/src/main/java/ru/shipcollision/api/StaticResourcesConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.GzipResourceResolver;
 
 import java.nio.file.Paths;
 
@@ -14,6 +15,8 @@ import java.nio.file.Paths;
 @EnableWebMvc
 public class StaticResourcesConfiguration implements WebMvcConfigurer {
 
+    public static final int CACHE_PERIOD = 3600;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         /*
@@ -23,6 +26,9 @@ public class StaticResourcesConfiguration implements WebMvcConfigurer {
          */
         final String resourseLocation = "file://" + Paths.get("uploads").toAbsolutePath().toString() + '/';
         registry.addResourceHandler("/uploads/**")
-                .addResourceLocations(resourseLocation);
+                .addResourceLocations(resourseLocation)
+                .setCachePeriod(CACHE_PERIOD)
+                .resourceChain(true)
+                .addResolver(new GzipResourceResolver());
     }
 }

--- a/src/main/java/ru/shipcollision/api/controllers/MeController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/MeController.java
@@ -73,7 +73,7 @@ public class MeController {
     }
 
     @PostMapping(path = "/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> doUploadAvatar(@RequestParam("file") MultipartFile avatar, HttpSession session) {
+    public ResponseEntity<?> doUploadAvatar(@RequestParam(value = "avatar") MultipartFile avatar, HttpSession session) {
         final User currentUser = sessionService.getCurrentUser(session);
 
         if (fileIOService.fileExists(currentUser.avatarLink)) {
@@ -91,6 +91,19 @@ public class MeController {
             ));
         }
     }
+
+    @DeleteMapping(path = "/avatar")
+    public ResponseEntity<?> doDeleteAvatar(HttpSession session) {
+        final User currentUser = sessionService.getCurrentUser(session);
+
+        if (fileIOService.fileExists(currentUser.avatarLink)) {
+            fileIOService.deleteFile(currentUser.avatarLink);
+            currentUser.avatarLink = null;
+        }
+
+        return ResponseEntity.ok().body(currentUser);
+    }
+
 
     @SuppressWarnings("PublicField")
     public static final class CreateOrFullUpdateRequest {

--- a/src/main/java/ru/shipcollision/api/controllers/MeController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/MeController.java
@@ -2,30 +2,48 @@ package ru.shipcollision.api.controllers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import ru.shipcollision.api.models.ApiMessage;
 import ru.shipcollision.api.models.User;
+import ru.shipcollision.api.services.FileIOService;
 import ru.shipcollision.api.services.SessionService;
 import ru.shipcollision.api.services.UserService;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ResourceBundle;
 
 /**
  * Контроллер для доступа к методам текущего пользователя.
  */
 @RestController
+@RequestMapping(path = "/me")
 public class MeController {
+
+    private final FileIOService fileIOService;
+
+    private final ServletContext servletContext;
 
     private final SessionService sessionService;
 
     private final UserService userService;
 
-    public MeController(SessionService sessionService, UserService userService) {
+    public MeController(FileIOService fileIOService,
+                        ServletContext servletContext,
+                        SessionService sessionService,
+                        UserService userService) {
+        this.fileIOService = fileIOService;
+        this.servletContext = servletContext;
         this.sessionService = sessionService;
         this.userService = userService;
     }
@@ -59,6 +77,21 @@ public class MeController {
         return ResponseEntity.ok().body(new ApiMessage(
                 "Your profile has been delete successfully. You are signed out"
         ));
+    }
+
+    @PostMapping(path = "/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> doUploadAvatar(@RequestParam("file") MultipartFile avatar, HttpSession session) {
+        final User currentUser = sessionService.getCurrentUser(session);
+        currentUser.avatarLink = fileIOService.saveAndGetPath(avatar);
+
+        try {
+            final URI avatarUri = new URI(currentUser.avatarLink);
+            return ResponseEntity.created(avatarUri).body(currentUser);
+        } catch (URISyntaxException e) {
+            return ResponseEntity.ok().body(new ApiMessage(
+                    "User has been created successfully, no resource URI available"
+            ));
+        }
     }
 
     @SuppressWarnings("PublicField")

--- a/src/main/java/ru/shipcollision/api/controllers/MeController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/MeController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.UnsupportedMediaTypeStatusException;
 import ru.shipcollision.api.models.ApiMessage;
 import ru.shipcollision.api.models.User;
 import ru.shipcollision.api.services.FileIOService;
@@ -26,6 +27,8 @@ import java.net.URISyntaxException;
 @RestController
 @RequestMapping(path = "/me")
 public class MeController {
+
+    private static final String AVATAR_CONTENT_TYPE_PATTERN = "^image/.+";
 
     private final FileIOService fileIOService;
 
@@ -73,7 +76,13 @@ public class MeController {
     }
 
     @PostMapping(path = "/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> doUploadAvatar(@RequestParam(value = "avatar") MultipartFile avatar, HttpSession session) {
+    public ResponseEntity<?> doUploadAvatar(@RequestPart(value = "avatar") MultipartFile avatar, HttpSession session) {
+        final String avatarContentType = avatar.getContentType();
+
+        if (!avatarContentType.matches(AVATAR_CONTENT_TYPE_PATTERN)) {
+            throw new UnsupportedMediaTypeStatusException(avatarContentType);
+        }
+
         final User currentUser = sessionService.getCurrentUser(session);
 
         if (fileIOService.fileExists(currentUser.avatarLink)) {

--- a/src/main/java/ru/shipcollision/api/controllers/MeController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/MeController.java
@@ -2,7 +2,6 @@ package ru.shipcollision.api.controllers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.beans.factory.annotation.Required;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
@@ -14,14 +13,12 @@ import ru.shipcollision.api.services.FileIOService;
 import ru.shipcollision.api.services.SessionService;
 import ru.shipcollision.api.services.UserService;
 
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ResourceBundle;
 
 /**
  * Контроллер для доступа к методам текущего пользователя.

--- a/src/main/java/ru/shipcollision/api/controllers/SessionsController.java
+++ b/src/main/java/ru/shipcollision/api/controllers/SessionsController.java
@@ -38,6 +38,7 @@ public class SessionsController {
     public ResponseEntity doSignin(@RequestBody @Valid SigninRequest signinRequest,
                                    HttpSession session) {
         final User user;
+
         try {
             user = userService.findByEmail(signinRequest.email);
         } catch (NotFoundException error) {
@@ -48,6 +49,7 @@ public class SessionsController {
             sessionService.openSession(session, user);
             return ResponseEntity.ok().body(new ApiMessage("You are signed in"));
         }
+
         throw new InvalidCredentialsException();
     }
 

--- a/src/main/java/ru/shipcollision/api/services/FileIOService.java
+++ b/src/main/java/ru/shipcollision/api/services/FileIOService.java
@@ -1,0 +1,12 @@
+package ru.shipcollision.api.services;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileIOService {
+
+    String saveAndGetPath(MultipartFile file);
+
+    MultipartFile load(String path);
+}

--- a/src/main/java/ru/shipcollision/api/services/FileIOService.java
+++ b/src/main/java/ru/shipcollision/api/services/FileIOService.java
@@ -2,8 +2,6 @@ package ru.shipcollision.api.services;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 public interface FileIOService {
 
     boolean fileExists(String resoursePath);

--- a/src/main/java/ru/shipcollision/api/services/FileIOService.java
+++ b/src/main/java/ru/shipcollision/api/services/FileIOService.java
@@ -6,7 +6,9 @@ import java.io.IOException;
 
 public interface FileIOService {
 
-    String saveAndGetPath(MultipartFile file);
+    boolean fileExists(String resoursePath);
 
-    MultipartFile load(String path);
+    String saveFileAndGetResourcePath(MultipartFile file);
+
+    void deleteFile(String resoursePath);
 }

--- a/src/main/java/ru/shipcollision/api/services/FileIOServiceImpl.java
+++ b/src/main/java/ru/shipcollision/api/services/FileIOServiceImpl.java
@@ -1,0 +1,63 @@
+package ru.shipcollision.api.services;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import ru.shipcollision.api.exceptions.ApiException;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+
+@Service
+public class FileIOServiceImpl implements FileIOService {
+
+    public static final String BASE_PATH = "uploads/";
+
+    private String resolveDirectoryPath(String originalFilename) {
+        final LocalDateTime now = LocalDateTime.now();
+        final String extension = originalFilename.split("\\.")[1];
+        final Path path = Paths.get(String.format("%s%d/%d/%d/",
+                BASE_PATH,
+                now.getYear(),
+                now.getMonthValue(),
+                now.getDayOfMonth()
+        )).toAbsolutePath();
+
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new ApiException(String.format("Impossible to create directory %s", path));
+        }
+
+        return String.format("%s/%d%d%d.%s",
+                path.toString(),
+                now.getHour(),
+                now.getMinute(),
+                now.getSecond(),
+                extension
+        );
+    }
+
+    @Override
+    public String saveAndGetPath(MultipartFile file) {
+        final String saveFilePath = resolveDirectoryPath(file.getOriginalFilename());
+
+        try (FileOutputStream out = new FileOutputStream(saveFilePath)) {
+            out.write(file.getBytes());
+            out.close();
+        } catch (FileNotFoundException e) {
+            throw new ApiException(String.format("File %s not found", saveFilePath));
+        } catch (IOException e) {
+            throw new ApiException(String.format("Impossible to save to file %s", saveFilePath));
+        }
+
+        return saveFilePath;
+    }
+
+    @Override
+    public MultipartFile load(String path) {
+        return null;
+    }
+}

--- a/src/main/java/ru/shipcollision/api/services/FileIOServiceImpl.java
+++ b/src/main/java/ru/shipcollision/api/services/FileIOServiceImpl.java
@@ -13,51 +13,78 @@ import java.time.LocalDateTime;
 @Service
 public class FileIOServiceImpl implements FileIOService {
 
-    public static final String BASE_PATH = "uploads/";
-
-    private String resolveDirectoryPath(String originalFilename) {
-        final LocalDateTime now = LocalDateTime.now();
-        final String extension = originalFilename.split("\\.")[1];
-        final Path path = Paths.get(String.format("%s%d/%d/%d/",
-                BASE_PATH,
-                now.getYear(),
-                now.getMonthValue(),
-                now.getDayOfMonth()
-        )).toAbsolutePath();
-
-        try {
-            Files.createDirectories(path);
-        } catch (IOException e) {
-            throw new ApiException(String.format("Impossible to create directory %s", path));
-        }
-
-        return String.format("%s/%d%d%d.%s",
-                path.toString(),
-                now.getHour(),
-                now.getMinute(),
-                now.getSecond(),
-                extension
-        );
-    }
+    public static final String BASE_PATH = "uploads";
 
     @Override
     public String saveAndGetPath(MultipartFile file) {
-        final String saveFilePath = resolveDirectoryPath(file.getOriginalFilename());
+        final UploadResourceResolver resolver = new UploadResourceResolver(file.getOriginalFilename());
 
-        try (FileOutputStream out = new FileOutputStream(saveFilePath)) {
+        try (FileOutputStream out = new FileOutputStream(resolver.getSaveFilePath())) {
             out.write(file.getBytes());
             out.close();
         } catch (FileNotFoundException e) {
-            throw new ApiException(String.format("File %s not found", saveFilePath));
+            throw new ApiException(String.format("File %s not found", resolver.getSaveFilePath()));
         } catch (IOException e) {
-            throw new ApiException(String.format("Impossible to save to file %s", saveFilePath));
+            throw new ApiException(String.format("Impossible to save to file %s", resolver.getSaveFilePath()));
         }
 
-        return saveFilePath;
+        return resolver.getResoursePath();
     }
 
     @Override
     public MultipartFile load(String path) {
         return null;
+    }
+
+    private static final class UploadResourceResolver {
+
+        private String filename;
+
+        private String resoursePath;
+
+        private String saveFilePath;
+
+        private UploadResourceResolver(String originalFilename) {
+            final LocalDateTime now = LocalDateTime.now();
+
+            final String fileExtension = originalFilename.split("\\.")[1];
+            filename = String.format(
+                    "%d%d%d.%s",
+                    now.getHour(),
+                    now.getMinute(),
+                    now.getSecond(),
+                    fileExtension
+            );
+
+            resoursePath = String.format(
+                    "%d/%d/%d",
+                    now.getYear(),
+                    now.getMonthValue(),
+                    now.getDayOfMonth()
+            );
+
+            final Path uploadPath = Paths.get(String.format(
+                    "%s/%s",
+                    BASE_PATH,
+                    resoursePath
+            )).toAbsolutePath();
+
+            try {
+                Files.createDirectories(uploadPath);
+            } catch (IOException e) {
+                throw new ApiException(String.format("Impossible to create directory %s", uploadPath));
+            }
+
+            resoursePath = String.format("/%s/%s/%s", BASE_PATH, resoursePath, filename);
+            saveFilePath = String.format("%s/%s", uploadPath.toString(), filename);
+        }
+
+        public String getResoursePath() {
+            return resoursePath;
+        }
+
+        public String getSaveFilePath() {
+            return saveFilePath;
+        }
     }
 }

--- a/src/main/java/ru/shipcollision/api/services/FileIOServiceImpl.java
+++ b/src/main/java/ru/shipcollision/api/services/FileIOServiceImpl.java
@@ -4,7 +4,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import ru.shipcollision.api.exceptions.ApiException;
 
-import java.io.*;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,11 +55,6 @@ public class FileIOServiceImpl implements FileIOService {
 
         private String saveFilePath;
 
-        public static Path toAbsolutePath(String resoursePath) {
-            resoursePath = (resoursePath != null && resoursePath.charAt(0) == '/') ? resoursePath.substring(1) : resoursePath;
-            return Paths.get(String.format("%s", resoursePath)).toAbsolutePath();
-        }
-
         private UploadResourceResolver(String originalFilename) {
             final LocalDateTime now = LocalDateTime.now();
 
@@ -91,6 +88,11 @@ public class FileIOServiceImpl implements FileIOService {
 
             resoursePath = String.format("/%s/%s/%s", BASE_PATH, resoursePath, filename);
             saveFilePath = String.format("%s/%s", uploadPath.toString(), filename);
+        }
+
+        public static Path toAbsolutePath(String resoursePath) {
+            resoursePath = (resoursePath != null && resoursePath.charAt(0) == '/') ? resoursePath.substring(1) : resoursePath;
+            return Paths.get(String.format("%s", resoursePath)).toAbsolutePath();
         }
 
         public String getResoursePath() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.servlet.multipart.max-file-size=20MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
+server.compression.enabled=true
 spring.servlet.multipart.max-file-size=20MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.compression.enabled=true
-spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=6MB


### PR DESCRIPTION
Прототип загрузки аватарок. Сейчас есть:
* [x] Загрузка аватара в локальную директорию
* [x] Базовая валидация контент-тайпа аватара
* [x] Удаление старого аватара при загрузке нового
* [x] Отдача аватара с помощью `Tomcat` со сжатием (вроде работает, но детально не проверял)
* [x] Возможность удалить свой аватар руками.

Немного о том, как это работает.

Есть маршрут `POST /me/avatar`, на который нужно отправить запрос **с контент-тайпом `multipart/form-data` и именем файла avatar**, который проверит, что в контент-тайпе есть слово `image` (так себе проверка, согласен) и если да, то сохранит файлик в директорию `uploads/год/месяц/день`. Имя файла - конкатенация текущего часа, минуты и секунды + расширение (берется из самого файла).

Директория `uploads` находится в корне проекта и **добавлена в .gitignore**. В коде `FileIOServiceImpl` есть автоматическое создание недостающих для сохранения файлов директорий, в том числе и самой `uploads`.

Получить загруженный файл можно по маршруту `uploads/год/месяц/день/имя.расширение`.
В файле `StaticResourcesConfiguration` есть маппинг маршрута `uploads` на соответствующие директории.

Максимальный размер файла для загрузки - 5 Мбайт, настроено сжатие статики (по крайней мере выполнено то, что сказано в туториале))0).

Спецификацию API версии `0.1.0` дополню в течение дня.